### PR TITLE
Sidebar matches new help docs structure

### DIFF
--- a/data/domains/yelp-endless.xml.in
+++ b/data/domains/yelp-endless.xml.in
@@ -28,54 +28,16 @@ ID: sidebar.link.index
 
 Appears on the static navigation sidebar.
 </its:locNote>
-<msgstr>Home</msgstr>
+<msgstr>Getting Started</msgstr>
 </msg>
 
-<msg id="sidebar.link.getting-started">
+<msg id="sidebar.link.net">
 <its:locNote>
-ID: sidebar.link.getting-started
+ID: sidebar.link.net
 
 Appears on the static navigation sidebar.
 </its:locNote>
-<msgstr>Getting started with your OS</msgstr>
-</msg>
-
-<msg id="sidebar.link.shell-introduction">
-<its:locNote>
-ID: sidebar.link.shell-introduction
-
-Appears on the static navigation sidebar.
-</its:locNote>
-<msgstr>Introduction to your OS</msgstr>
-</msg>
-
-<msg id="sidebar.link.shell-exit">
-<its:locNote>
-ID: sidebar.link.shell-exit
-
-Appears on the static navigation sidebar.
-</its:locNote>
-<msgstr>Log out, power off or switch users</msgstr>
-</msg>
-
-<msg id="sidebar.link.shell-apps-open">
-<its:locNote>
-ID: sidebar.link.shell-apps-open
-
-Appears on the static navigation sidebar.
-</its:locNote>
-<msgstr>Start applications</msgstr>
-</msg>
-
-<msg id="sidebar.link.shell-overview">
-<its:locNote>
-ID: sidebar.link.shell-overview
-
-Appears on the static navigation sidebar. Make sure that the string is
-XML-escaped, e.g. &amp;, &gt;, &lt;, &quot;, &apos;, are replaced by &amp;amp;,
-&amp;gt;, &amp;lt;, &amp;quot;, and &amp;apos; respectively.
-</its:locNote>
-<msgstr>Desktop Apps &amp; Windows</msgstr>
+<msgstr>Internet</msgstr>
 </msg>
 
 <msg id="sidebar.link.files">
@@ -86,7 +48,27 @@ Appears on the static navigation sidebar. Make sure that the string is
 XML-escaped, e.g. &amp;, &gt;, &lt;, &quot;, &apos;, are replaced by &amp;amp;,
 &amp;gt;, &amp;lt;, &amp;quot;, and &amp;apos; respectively.
 </its:locNote>
-<msgstr>Files, Folders &amp; Search</msgstr>
+<msgstr>Documents &amp; Files</msgstr>
+</msg>
+
+<msg id="sidebar.link.shell-overview">
+<its:locNote>
+ID: sidebar.link.shell-overview
+
+Appears on the static navigation sidebar.
+</its:locNote>
+<msgstr>The Desktop</msgstr>
+</msg>
+
+<msg id="sidebar.link.hardware">
+<its:locNote>
+ID: sidebar.link.hardware
+
+Appears on the static navigation sidebar. Make sure that the string is
+XML-escaped, e.g. &amp;, &gt;, &lt;, &quot;, &apos;, are replaced by &amp;amp;,
+&amp;gt;, &amp;lt;, &amp;quot;, and &amp;apos; respectively.
+</its:locNote>
+<msgstr>Printers, Displays &amp; Accessories</msgstr>
 </msg>
 
 <msg id="sidebar.link.a11y">
@@ -98,68 +80,15 @@ Appears on the static navigation sidebar.
 <msgstr>Universal Access</msgstr>
 </msg>
 
-<msg id="sidebar.link.net">
+<msg id="sidebar.link.security-and-privacy">
 <its:locNote>
-ID: sidebar.link.net
+ID: sidebar.link.security-and-privacy
 
 Appears on the static navigation sidebar. Make sure that the string is
 XML-escaped, e.g. &amp;, &gt;, &lt;, &quot;, &apos;, are replaced by &amp;amp;,
 &amp;gt;, &amp;lt;, &amp;quot;, and &amp;apos; respectively.
 </its:locNote>
-<msgstr>Networking, Web, Email &amp; Chat</msgstr>
-</msg>
-
-<msg id="sidebar.link.prefs">
-<its:locNote>
-ID: sidebar.link.prefs
-
-Appears on the static navigation sidebar. Make sure that the string is
-XML-escaped, e.g. &amp;, &gt;, &lt;, &quot;, &apos;, are replaced by &amp;amp;,
-&amp;gt;, &amp;lt;, &amp;quot;, and &amp;apos; respectively.
-</its:locNote>
-<msgstr>User &amp; System Settings</msgstr>
-</msg>
-
-<msg id="sidebar.link.tips">
-<its:locNote>
-ID: sidebar.link.tips
-
-Appears on the static navigation sidebar. Make sure that the string is
-XML-escaped, e.g. &amp;, &gt;, &lt;, &quot;, &apos;, are replaced by &amp;amp;,
-&amp;gt;, &amp;lt;, &amp;quot;, and &amp;apos; respectively.
-</its:locNote>
-<msgstr>Tips &amp; Tricks</msgstr>
-</msg>
-
-<msg id="sidebar.link.media">
-<its:locNote>
-ID: sidebar.link.media
-
-Appears on the static navigation sidebar. Make sure that the string is
-XML-escaped, e.g. &amp;, &gt;, &lt;, &quot;, &apos;, are replaced by &amp;amp;,
-&amp;gt;, &amp;lt;, &amp;quot;, and &amp;apos; respectively.
-</its:locNote>
-<msgstr>Sound, Video &amp; Pictures</msgstr>
-</msg>
-
-<msg id="sidebar.link.hardware">
-<its:locNote>
-ID: sidebar.link.hardware
-
-Appears on the static navigation sidebar. Make sure that the string is
-XML-escaped, e.g. &amp;, &gt;, &lt;, &quot;, &apos;, are replaced by &amp;amp;,
-&amp;gt;, &amp;lt;, &amp;quot;, and &amp;apos; respectively.
-</its:locNote>
-<msgstr>Hardware &amp; Drivers</msgstr>
-</msg>
-
-<msg id="sidebar.link.more-help">
-<its:locNote>
-ID: sidebar.link.more-help
-
-Appears on the static navigation sidebar.
-</its:locNote>
-<msgstr>Get more help</msgstr>
+<msgstr>Security &amp; Privacy</msgstr>
 </msg>
 
 <msg id="sidebar.link.endless-videos">
@@ -168,7 +97,7 @@ ID: sidebar.link.endless-videos
 
 Appears on the static navigation sidebar.
 </its:locNote>
-<msgstr>Video Tutorials</msgstr>
+<msgstr>Video Library</msgstr>
 </msg>
 
 </l10n>

--- a/data/xslt/endless-customizations.xsl.in
+++ b/data/xslt/endless-customizations.xsl.in
@@ -33,26 +33,6 @@
       </xsl:call-template>
     </a></h3>
     <ol>
-      <li><a href="help:gnome-help/getting-started"><span>
-        <xsl:call-template name="l10n-endless-text">
-          <xsl:with-param name="msgid" select="'sidebar.link.getting-started'"/>
-        </xsl:call-template>
-      </span></a></li>
-      <li><a href="help:gnome-help/shell-introduction"><span>
-        <xsl:call-template name="l10n-endless-text">
-          <xsl:with-param name="msgid" select="'sidebar.link.shell-introduction'"/>
-        </xsl:call-template>
-      </span></a></li>
-      <li><a href="help:gnome-help/shell-exit"><span>
-        <xsl:call-template name="l10n-endless-text">
-          <xsl:with-param name="msgid" select="'sidebar.link.shell-exit'"/>
-        </xsl:call-template>
-      </span></a></li>
-      <li><a href="help:gnome-help/shell-apps-open"><span>
-        <xsl:call-template name="l10n-endless-text">
-          <xsl:with-param name="msgid" select="'sidebar.link.shell-apps-open'"/>
-        </xsl:call-template>
-      </span></a></li>
       <li><a href="help:gnome-help/shell-overview"><span>
         <xsl:call-template name="l10n-endless-text">
           <xsl:with-param name="msgid" select="'sidebar.link.shell-overview'"/>
@@ -68,19 +48,19 @@
           <xsl:with-param name="msgid" select="'sidebar.link.net'"/>
         </xsl:call-template>
       </span></a></li>
-      <li><a href="help:gnome-help/prefs"><span>
-        <xsl:call-template name="l10n-endless-text">
-          <xsl:with-param name="msgid" select="'sidebar.link.prefs'"/>
-        </xsl:call-template>
-      </span></a></li>
-      <li><a href="help:gnome-help/tips"><span>
-        <xsl:call-template name="l10n-endless-text">
-          <xsl:with-param name="msgid" select="'sidebar.link.tips'"/>
-        </xsl:call-template>
-      </span></a></li>
       <li><a href="help:gnome-help/hardware"><span>
         <xsl:call-template name="l10n-endless-text">
           <xsl:with-param name="msgid" select="'sidebar.link.hardware'"/>
+        </xsl:call-template>
+      </span></a></li>
+      <li><a href="help:gnome-help/security-and-privacy"><span>
+        <xsl:call-template name="l10n-endless-text">
+          <xsl:with-param name="msgid" select="'sidebar.link.security-and-privacy'"/>
+        </xsl:call-template>
+      </span></a></li>
+      <li><a href="help:gnome-help/a11y"><span>
+        <xsl:call-template name="l10n-endless-text">
+          <xsl:with-param name="msgid" select="'sidebar.link.a11y'"/>
         </xsl:call-template>
       </span></a></li>
       <li><a href="help:gnome-help/endless-videos"><span>


### PR DESCRIPTION
We've done a big re-layout of the structure of pages in gnome-user-docs,
update our sidebar links to point to the new top level elements and properly
match names with the actual articles
[endlessm/eos-shell#3910]
