### PR TITLE
Fix X button to appear as X

### DIFF
--- a/data/endless/css/article-style.css
+++ b/data/endless/css/article-style.css
@@ -564,23 +564,18 @@ div.ui-tile .center {
 a.ui-overlay-close {
     padding-top: 0px;
     font-weight: normal;
-    color: rgba(0,0,0,0);
+    color: #fff;
     line-height: .95rem;
     text-shadow: none;
+    font-size: .90rem;
+}
+
+a.ui-overlay-close:hover {
+    text-decoration: none;
 }
 
 div.ui-screen {
     z-index: 5;
-}
-
-a.ui-overlay-close:before {
-    color: #fff;
-    content: "\f00d";
-    font-family: 'FontAwesome';
-    font-size: .90rem;
-    left: .055rem;
-    position: relative;
-    top: -.05rem;
 }
 
 div.media-controls.media-controls-VIDEO {


### PR DESCRIPTION
Part of the absolute mess that is the css right now
with groupo premeirs css applied along with the gnome css and battling
each other in all sorts of ways.

So the article-style css turned the "gnome" x character transparent, and
added their own x character with the :before selector, which used the
font awesome typeface, which used a unicode character which usually
appears as a chinese character...

Rather than bring all that madness back, just used the "gnome" x character.
We can restyle as desired as part of our unify/update css issue.
[endlessm/eos-shell#4225]
