### PR TITLE
Don't hard code font-size or font-family in style sheets

### DIFF
--- a/data/endless/css/article-style.css
+++ b/data/endless/css/article-style.css
@@ -1,8 +1,7 @@
 body {
     background-color: transparent;
     color: #5f5f5f;
-    font-family: 'latoregular', sans-serif;
-    font-size: 15px;
+    font-size: 0.938em;
 }
 
 hr {

--- a/data/endless/css/eos-help-center-style.css
+++ b/data/endless/css/eos-help-center-style.css
@@ -2,10 +2,11 @@
  * Style for eos-help-center
  */
 
-html,
+html {
+    font-size: 1.0666em;
+}
+
 body {
-    font-family: 'latoregular', sans-serif;
-    font-size: 16px;
     height: 100%;
     min-height: 200px;
     min-width: 40em;


### PR DESCRIPTION
All font sized should be em or rem so that the font sizes can be changed
though the top bar menu options in yelp

The font family will be picked up as lato from the system theme
[endlessm/eos-shell#4222]
