### PR TITLE
Use GtkSettings 'gtk-xft-dpi' property to keep track of Xft DPI changes

### DIFF
--- a/libyelp/yelp-view.c
+++ b/libyelp/yelp-view.c
@@ -128,6 +128,9 @@ static void        document_callback              (YelpDocument       *document,
                                                    YelpDocumentSignal  signal,
                                                    YelpView           *view,
                                                    GError             *error);
+static void        gtk_xft_dpi_changed            (GtkSettings        *gtk_settings,
+                                                   GParamSpec         *pspec,
+                                                   gpointer            user_data);
 
 static gchar *nautilus_sendto = NULL;
 
@@ -196,6 +199,8 @@ struct _YelpViewPrivate {
     gulong         uri_resolved;
     gchar         *bogus_uri;
     YelpDocument  *document;
+    GtkSettings   *gtk_settings;
+    gulong         gtk_xft_dpi_changed;
     GCancellable  *cancellable;
     GtkAdjustment *vadjustment;
     GtkAdjustment *hadjustment;
@@ -250,6 +255,17 @@ yelp_view_init (YelpView *view)
     priv->cancellable = NULL;
 
     priv->prevstate = priv->state = YELP_VIEW_STATE_BLANK;
+
+    /* FIXME: We should use the GtkSettings from the right GdkScreen instead
+     * of the the detault one, but we can't get it from here since the view
+     * has not been added to any top level GtkWidget yet.
+     */
+    priv->gtk_settings = gtk_settings_get_default ();
+    if (priv->gtk_settings) {
+        priv->gtk_xft_dpi_changed =
+            g_signal_connect (priv->gtk_settings, "notify::gtk-xft-dpi",
+                              G_CALLBACK (gtk_xft_dpi_changed), NULL);
+    }
 
     priv->navigation_requested =
         g_signal_connect (view, "navigation-policy-decision-requested",
@@ -308,6 +324,11 @@ yelp_view_dispose (GObject *object)
     YelpViewPrivate *priv = GET_PRIV (object);
 
     view_clear_load (YELP_VIEW (object));
+
+    if (priv->gtk_xft_dpi_changed > 0) {
+        g_signal_handler_disconnect (priv->gtk_settings, priv->gtk_xft_dpi_changed);
+        priv->gtk_xft_dpi_changed = 0;
+    }
 
     if (priv->vadjuster > 0) {
         g_signal_handler_disconnect (priv->vadjustment, priv->vadjuster);
@@ -1842,6 +1863,25 @@ view_show_error_page (YelpView *view,
     g_free (page);
 }
 
+static gint
+normalize_font_size (gdouble font_size)
+{
+  GtkSettings *settings = NULL;
+  gint gtk_xft_dpi = -1;
+  gdouble dpi = 96;
+
+  /* FIXME: We should use the GtkSettings from the right GdkScreen instead
+   * of the the detault one, but we don't have access to the view here.
+   */
+  settings = gtk_settings_get_default ();
+  if (settings) {
+      g_object_get (settings, "gtk-xft-dpi", &gtk_xft_dpi, NULL);
+      dpi = (gtk_xft_dpi != -1) ? gtk_xft_dpi / 1024.0 : 96;
+  }
+
+  /* Use 96 DPI as the reference value for font size calculation */
+  return font_size * dpi / 96;
+}
 
 static void
 settings_set_fonts (YelpSettings *settings)
@@ -1861,7 +1901,7 @@ settings_set_fonts (YelpSettings *settings)
     g_object_set (websettings,
                   "default-font-family", family,
                   "sans-serif-font-family", family,
-                  "default-font-size", size,
+                  "default-font-size", normalize_font_size (size),
                   NULL);
     g_free (family);
 
@@ -1871,7 +1911,7 @@ settings_set_fonts (YelpSettings *settings)
                                         YELP_SETTINGS_FONT_FIXED);
     g_object_set (websettings,
                   "monospace-font-family", family,
-                  "default-monospace-font-size", size,
+                  "default-monospace-font-size", normalize_font_size (size),
                   NULL);
     g_free (family);
 }
@@ -2196,4 +2236,13 @@ document_callback (YelpDocument       *document,
     else if (signal == YELP_DOCUMENT_SIGNAL_ERROR) {
         view_show_error_page (view, error);
     }
+}
+
+static void
+gtk_xft_dpi_changed (GtkSettings *gtk_settings,
+                     GParamSpec  *pspec,
+                     gpointer     user_data)
+{
+    YelpSettings *settings = yelp_settings_get_default ();
+    settings_set_fonts (settings);
 }


### PR DESCRIPTION
Use that property to find the DPI resolution for font handling, in order
to calculate the effective font size value that needs to be passed to
WebKitSettings when setting the default values. Also, connect to
notify::gtk-xft-dpi so that we can update the font size whenever the
DPI value changes, and not just on startup.

https://bugzilla.gnome.org/show_bug.cgi?id=744921

[endlessm/eos-shell#4615]