### PR TITLE
Use dh_eoscontent to merge Endless desktop customizations

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Standards-Version: 3.9.4
 Build-Depends: debhelper (>= 8),
                gnome-pkg-tools (>= 0.10),
                cdbs (>= 0.4.41),
+               eos-shell-content-dev,
                docbook-to-man,
                intltool (>= 0.41.0),
                itstool (>= 1.2.0),

--- a/debian/control.in
+++ b/debian/control.in
@@ -7,6 +7,7 @@ Standards-Version: 3.9.4
 Build-Depends: debhelper (>= 8),
                gnome-pkg-tools (>= 0.10),
                cdbs (>= 0.4.41),
+               eos-shell-content-dev,
                docbook-to-man,
                intltool (>= 0.41.0),
                itstool (>= 1.2.0),

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,7 @@ include /usr/share/cdbs/1/rules/utils.mk
 include /usr/share/cdbs/1/class/gnome.mk
 include /usr/share/gnome-pkg-tools/1/rules/uploaders.mk
 -include /usr/share/gnome-pkg-tools/1/rules/gnome-get-source.mk
+include /usr/share/cdbs/1/rules/eoscontent.mk
 
 DEB_DH_MAKESHLIBS_ARGS_ALL += -V -- -c4
 LDFLAGS += -Wl,-z,defs -Wl,-O1 -Wl,--as-needed


### PR DESCRIPTION
Include the CDBS rules to use dh_eoscontent from eos-shell-content-dev
so that Endless content changes are merged in the desktop file.

[endlessm/eos-shell#5272]