### PR TITLE
application: don't steal activation timestamp

### DIFF
--- a/src/yelp-application.c
+++ b/src/yelp-application.c
@@ -236,7 +236,7 @@ yelp_application_cmdline (GApplication     *app,
     gint i;
 
     context = g_option_context_new (NULL);
-    g_option_context_add_group (context, gtk_get_option_group (TRUE));
+    g_option_context_add_group (context, gtk_get_option_group (FALSE));
     g_option_context_add_main_entries (context, entries, GETTEXT_PACKAGE);
     g_option_context_parse (context, &argc, arguments, NULL);
 


### PR DESCRIPTION
When using GtkApplication, nothing else should open the display before
GtkApplication does. We should pass FALSE to gtk_get_option_group() to
get that behavior.

This fixes startup notification not working correctly for Yelp when the
binary is already running.

[endlessm/eos-shell#5483]