### PR TITLE
yelp-document: Fix return type of document_indexed

### DIFF
--- a/libyelp/yelp-document.c
+++ b/libyelp/yelp-document.c
@@ -114,7 +114,7 @@ static gboolean       document_request_page     (YelpDocument         *document,
                                                  GCancellable         *cancellable,
                                                  YelpDocumentCallback  callback,
                                                  gpointer              user_data);
-static void           document_indexed          (YelpDocument         *document);
+static gboolean       document_indexed          (YelpDocument         *document);
 static const gchar *  document_read_contents    (YelpDocument         *document,
                                                  const gchar          *page_id);
 static void           document_finish_read      (YelpDocument         *document,
@@ -786,7 +786,7 @@ yelp_document_set_page_icon (YelpDocument *document,
     g_mutex_unlock (&document->priv->mutex);
 }
 
-static void
+static gboolean
 document_indexed (YelpDocument *document)
 {
     g_mutex_lock (&document->priv->mutex);
@@ -799,6 +799,8 @@ document_indexed (YelpDocument *document)
                                                            document->priv->reqs_search);
     }
     g_mutex_unlock (&document->priv->mutex);
+
+    return FALSE;
 }
 
 /******************************************************************************/


### PR DESCRIPTION
It's a GSourceFunc, so it'd better return a gboolean. This doesn't seem
to be causing any problems in Fedora, but in Endless it's causing 100%
CPU usage after executing a search, because the source never gets
removed.

https://bugzilla.gnome.org/show_bug.cgi?id=761647

[endlessm/eos-shell#6325]