### PR TITLE
Fix wrong generator rule for target data/domains/yelp.pot

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -359,7 +359,7 @@ dist_scalableicon_DATA = \
 
 domaindir = $(datadir)/yelp-xsl/xslt/common/domains
 
-data/domains/yelp.pot data/domains/yelp-endless.xml.in: data/domains/yelp.xml.in
+data/domains/yelp.pot: data/domains/yelp-endless.xml.in data/domains/yelp.xml.in
 	$(ITSTOOL) -o "$@" $^
 
 data/domains/%.xml: data/domains/%.xml.in


### PR DESCRIPTION
The way it was declared before (2 targets with 1 dependency, instead of
1 target with 2 dependencies) was causing a race condition with how itstool
was being run for yelp-endless.xml, resulting in generating an empty file.

The problem happened because the current way the rule was written caused that
a `itstool -o data/domains/yelp-endless.xml.in data/domains/yelp.xml.in` got
executed at some point, which would overwrite yelp-endless.xml.in as if it was
a POT file, thus producing the following error when the final yelp-endless.xml
was being generated, which would end up becoming an empty file.

  Error: Could not parse document:
   data/domains/yelp-endless.xml.in:1:  parser  error :  Start tag expected, '<' not found
   msgid ""

Surprisingly enough, this worked fine some times when the itstool command that
would overwrite the yelp-endless.xml.in file got executed after the one that would
generate the final yelp-endless.xml, which is why this was so hard to spot.

Thus, the right solution here is to simply declare one target to generate the
yelp.po file, with 2 dependencies, so that the bogus itstool command is never run.

https://phabricator.endlessm.com/T13567