### PR TITLE
search-provider: replace signals

### DIFF
--- a/search-provider/yelp-search-provider.c
+++ b/search-provider/yelp-search-provider.c
@@ -400,10 +400,10 @@ preload_data_cb (YelpDocument          *document,
         return;
     }
 
-    if (signal == YELP_DOCUMENT_SIGNAL_CONTENTS)
+    if (signal == YELP_DOCUMENT_SIGNAL_INFO)
         return;
 
-    if (signal == YELP_DOCUMENT_SIGNAL_INFO) {
+    if (signal == YELP_DOCUMENT_SIGNAL_CONTENTS) {
         for (iter = page_ids; *iter; iter++) {
             gchar *page_id = *iter;
             PageData *data;


### PR DESCRIPTION
This fixes a problem we were seeing, where not all data was being
preloaded in y-s-p. We should be instead waiting for
YELP_DOCUMENT_SIGNAL_CONTENTS signal.

Semantics of INFO and CONTENTS signal are not documented, so
it is not clear whether we can get all the page ids from
document after getting the INFO signal. Because of this we
rather wait for the CONTENTS signal.

@rshuler @cosimoc 

https://phabricator.endlessm.com/T10165