### PR TITLE
desktop: remove DBusActivatable

### DIFF
--- a/org.gnome.Yelp.desktop.in.in
+++ b/org.gnome.Yelp.desktop.in.in
@@ -7,7 +7,6 @@ Exec=yelp %u
 Icon=help-browser
 StartupNotify=true
 Terminal=false
-DBusActivatable=true
 Type=Application
 Categories=GNOME;GTK;Core;Documentation;Utility;
 X-GNOME-Bugzilla-Bugzilla=GNOME


### PR DESCRIPTION
This prevented our Yelp application from launching normally. Instead
this caused the Exec line of additional desktop actions to be ignored,
and Yelp was started by way of D-Bus activation instead every time.

@cosimoc @rshuler

https://phabricator.endlessm.com/T10165