### PR TITLE
icons: Install Yelp's icons outside of private dir, in /usr/share/icons

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -338,8 +338,8 @@ desktop_DATA = $(desktop_in_files:.desktop.in.in=.desktop)
 gsettings_SCHEMAS = data/org.gnome.yelp.gschema.xml
 @GSETTINGS_RULES@
 
-16icondir = $(pkgdatadir)/icons/hicolor/16x16/status
-scalableicondir = $(pkgdatadir)/icons/hicolor/scalable/status
+16icondir = $(datadir)/icons/hicolor/16x16/status
+scalableicondir = $(datadir)/icons/hicolor/scalable/status
 
 dist_16icon_DATA = \
 	data/icons/hicolor/16x16/status/bookmark.png \

--- a/libyelp/yelp-settings.c
+++ b/libyelp/yelp-settings.c
@@ -553,15 +553,6 @@ yelp_settings_set_property (GObject      *object,
 	    if (append_search_path)
 		gtk_icon_theme_append_search_path (settings->priv->gtk_icon_theme,
 						   YELP_ICON_PATH);
-            append_search_path = TRUE;
-	    for (i = search_path_len - 1; i >= 0; i--)
-		if (g_str_equal (search_path[i], DATADIR"/yelp/icons")) {
-		    append_search_path = FALSE;
-		    break;
-		}
-	    if (append_search_path)
-		gtk_icon_theme_append_search_path (settings->priv->gtk_icon_theme,
-                                                   DATADIR"/yelp/icons");
 	    g_strfreev (search_path);
 	    g_object_ref (settings->priv->gtk_icon_theme);
 	    settings->priv->icon_theme_changed =


### PR DESCRIPTION
These icons are normally used by Yelp only, so it makes sense they are
in a private directory, but with our addition of a search provider for
the shell, we need to move them into a standard location so that the
they can be found by the shell when search results are provided.

This is necessary because the provider serializes a GThemedIcon which
only contains the icon name for the themeable icon, which the shell
won't be able to find if they live in Yelp's private directory.

https://phabricator.endlessm.com/T18065