### PR TITLE
Fix multiple problems with .desktop generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -327,8 +327,8 @@ install-exec-hook:
 	$(LN_S) yelp $(DESTDIR)$(bindir)/gnome-help
 
 desktopdir = $(datadir)/applications
-desktop_DATA = yelp.desktop
-yelp.desktop: ${srcdir}/org.gnome.Yelp.desktop.in.in
+desktop_DATA = org.gnome.Yelp.desktop
+org.gnome.Yelp.desktop: ${srcdir}/org.gnome.Yelp.desktop.in.in
 	$(AM_V_GEN)$(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 data/yelp.appdata.xml: ${srcdir}/data/yelp.appdata.xml.in

--- a/org.gnome.Yelp.desktop.in.in
+++ b/org.gnome.Yelp.desktop.in.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
-_Name=Help
-_Comment=Get help with GNOME
-_Keywords=documentation;information;manual;help;
+Name=Help
+Comment=Get help with GNOME
+Keywords=documentation;information;manual;help;
 OnlyShowIn=GNOME;Unity;
 Exec=yelp %u
 Icon=help-browser


### PR DESCRIPTION
This is a fallout from rebase over 3.32.0 [1].

* Makefile.am: Use correct .desktop filename when generating it
  (i.e. org.gnome.Yelp.desktop).
* Yelp moved to gettext from intltools for translations. Gettext
  natively understands .desktop file-formats so remove the "_" sentinels [2].

[1] https://github.com/endlessm/yelp/pull/53
[2] https://gitlab.gnome.org/GNOME/yelp/merge_requests/11#note_492915

https://phabricator.endlessm.com/T25371