### PR TITLE
control: Add Eos-AppID as org.gnome.Yelp

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,7 @@ Homepage: https://wiki.gnome.org/Apps/Yelp
 
 Package: yelp
 Architecture: any
+XCBS-EOS-AppId: org.gnome.Yelp
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          libyelp0 (= ${binary:Version}),

--- a/debian/control.in
+++ b/debian/control.in
@@ -30,6 +30,7 @@ Homepage: https://wiki.gnome.org/Apps/Yelp
 
 Package: yelp
 Architecture: any
+XCBS-EOS-AppId: org.gnome.Yelp
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          libyelp0 (= ${binary:Version}),


### PR DESCRIPTION
Downstream desktop files changes(Name, Icon and translations) comes from
eos-shell-content but recent yelp-3.32 rebase did not reflect those changes
in the recent builds of OS. This problem was also noticed earlier and only
a quick fix was written [1].

However, after digging a bit and seeing how changes from eos-shell-content
gets plugged in, the problem become apparent. dh_eoscontent picks up desktop
file (for merging) via the Eos-AppId tag in debian/control. As there is no
Eos-AppId in yelp's debian packaging currently, the desktop file from eos-shell-content
was not getting merged with what is provided by the package. Hence, provide the
app-id for the expected result.

[1] https://github.com/endlessm/yelp/commit/6087b631217e1859509

https://phabricator.endlessm.com/T25371