### PR TITLE
appdata: Match appdata 's app-id with desktop file

### DIFF
--- a/data/yelp.appdata.xml.in
+++ b/data/yelp.appdata.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>yelp.desktop</id>
+  <id>org.gnome.Yelp.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>GNOME Help</name>


### PR DESCRIPTION
We rename the desktop file of yelp downstream since last 2 rebases.
To ensure correct mapping with the new renamed file and this appdata
file, change the app-id in appdata as per the desktop file.

The desktop file, like many other core-apps live inside
eos-shell-content CMS.

This actually fixes icon missing issue specific to yelp.

https://phabricator.endlessm.com/T27779#762354

https://phabricator.endlessm.com/T27779