### PR TITLE
T30176 Rebase on 3.38 (Debian)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,33 @@
-yelp (3.36.0-0endless1) master; urgency=medium
+yelp (3.38.0-1) unstable; urgency=medium
 
-  * Re-apply Endless changes on latest upstream release:
-    - Support eoscontent/eos-shell-content
-    - Add XCBS-EOS-AppId to override app ID when bundling
+  * New upstream release
 
- -- Philip Withnall <withnall@endlessm.com>  Mon, 09 Mar 2020 17:51:00 +0000
+ -- Sebastien Bacher <seb128@ubuntu.com>  Tue, 15 Sep 2020 13:43:37 +0200
+
+yelp (3.37.90-1) experimental; urgency=medium
+
+  * New upstream release
+
+ -- Sebastien Bacher <seb128@ubuntu.com>  Mon, 10 Aug 2020 12:38:37 +0200
+
+yelp (3.36.0-1) unstable; urgency=medium
+
+  * Upload to unstable
+
+  [ Laurent Bigonville ]
+  * debian/control.in: Make yelp recommends docbook-xml, (lib)yelp tries to
+    load /etc/xml/catalog, if this file doesn't exist, it falls back to the
+    yelp internal faux catalog. But the fact that /etc/xml/catalog exits
+    doesn't mean that the needed docbookx dtd are installed.
+  * New upstream release
+  * Bump debhelper compatibility to 12
+  * debian/control.in: Bump Standards-Version to 4.5.0 (no further changes)
+
+  [ Ken VanDine ]
+  * debian/patches/required-content_rating-and-releases-appdata.patch
+    - Added tags required for validation, fixing FTBFS due to test failures
+
+ -- Sebastien Bacher <seb128@ubuntu.com>  Tue, 07 Apr 2020 22:15:37 +0200
 
 yelp (3.34.0-1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+yelp (3.38.0-1endless0) eos; urgency=medium
+
+  * Re-apply Endless changes on latest upstream release (T30176):
+    - Support search provider
+    - Drop `XCBS-EOS-AppId` metadata, as that was only used on eos3.2 and
+      earlier
+    - Drop eos-shell-content-dev dependency as EOS style customisations have been
+      removed
+
+ -- Philip Withnall <pwithnall@endlessos.org>  Wed, 16 Sep 2020 13:55:00 +0100
+
 yelp (3.38.0-1) unstable; urgency=medium
 
   * New upstream release

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,6 @@ Build-Depends: appstream-util,
                debhelper-compat (= 12),
                gnome-pkg-tools (>= 0.10),
                docbook-to-man,
-               eos-shell-content-dev,
                itstool (>= 1.2.0),
                gtk-doc-tools,
                libglib2.0-doc,
@@ -34,7 +33,6 @@ Homepage: https://wiki.gnome.org/Apps/Yelp
 
 Package: yelp
 Architecture: any
-XCBS-EOS-AppId: org.gnome.Yelp
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          libyelp0 (= ${binary:Version}),

--- a/debian/control.in
+++ b/debian/control.in
@@ -8,7 +8,6 @@ Build-Depends: appstream-util,
                debhelper-compat (= 12),
                gnome-pkg-tools (>= 0.10),
                docbook-to-man,
-               eos-shell-content-dev,
                itstool (>= 1.2.0),
                gtk-doc-tools,
                libglib2.0-doc,
@@ -30,7 +29,6 @@ Homepage: https://wiki.gnome.org/Apps/Yelp
 
 Package: yelp
 Architecture: any
-XCBS-EOS-AppId: org.gnome.Yelp
 Depends: ${shlibs:Depends},
          ${misc:Depends},
          libyelp0 (= ${binary:Version}),

--- a/debian/patches/disable_package_search.patch
+++ b/debian/patches/disable_package_search.patch
@@ -14,11 +14,11 @@ Bug: https://bugs.launchpad.net/bugs/838540
  libyelp/yelp-view.c | 4 ----
  1 file changed, 4 deletions(-)
 
-diff --git a/libyelp/yelp-view.c b/libyelp/yelp-view.c
-index 183506e..f9da4fb 100644
---- a/libyelp/yelp-view.c
-+++ b/libyelp/yelp-view.c
-@@ -1987,10 +1987,6 @@ view_show_error_page (YelpView *view,
+Index: yelp-3.38.0/libyelp/yelp-view.c
+===================================================================
+--- yelp-3.38.0.orig/libyelp/yelp-view.c
++++ yelp-3.38.0/libyelp/yelp-view.c
+@@ -1988,10 +1988,6 @@ view_show_error_page (YelpView *view,
              scheme = "ghelp";
              pkg = struri + 6;
          }

--- a/debian/patches/required-content_rating-and-releases-appdata.patch
+++ b/debian/patches/required-content_rating-and-releases-appdata.patch
@@ -1,0 +1,121 @@
+From 6f2d0cbe4342ad11333659e8b40cd56df2b586d7 Mon Sep 17 00:00:00 2001
+From: Ken VanDine <ken@vandine.org>
+Date: Tue, 7 Apr 2020 10:58:43 -0400
+Subject: [PATCH] Added required content_rating and releases to appdata, fixes
+ #153
+
+---
+ data/yelp.appdata.xml.in | 99 ++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 99 insertions(+)
+
+diff --git a/data/yelp.appdata.xml.in b/data/yelp.appdata.xml.in
+index 41742d27..24736a33 100644
+--- a/data/yelp.appdata.xml.in
++++ b/data/yelp.appdata.xml.in
+@@ -28,4 +28,103 @@
+   <compulsory_for_desktop>GNOME</compulsory_for_desktop>
+   <translation type="gettext">yelp</translation>
+   <developer_name>The GNOME Project</developer_name>
++  <content_rating type="oars-1.1" />
++  <releases>
++    <release version="3.36.0" date="2020-03-06" />
++    <release version="3.34.0" date="2019-09-09" />
++    <release version="3.33.92" date="2019-09-02" />
++    <release version="3.32.2" date="2019-05-07" />
++    <release version="3.32.1" date="2019-04-08" />
++    <release version="3.32.0" date="2019-03-11" />
++    <release version="3.31.90" date="2019-02-04" />
++    <release version="3.30.0" date="2018-09-03" />
++    <release version="3.28.1" date="2018-04-10" />
++    <release version="3.28.0" date="2018-03-13" />
++    <release version="3.27.1" date="2017-10-16" />
++    <release version="3.20.1" date="2016-04-11" />
++    <release version="3.20.0" date="2016-03-21" />
++    <release version="3.19.91" date="2016-03-01" />
++    <release version="3.19.90" date="2016-02-15" />
++    <release version="3.19.1" date="2015-10-26" />
++    <release version="3.18.1," date="2015-10-12" />
++    <release version="3.18.0" date="2015-09-21" />
++    <release version="3.17.3" date="2015-06-23" />
++    <release version="3.17.2" date="2015-05-25" />
++    <release version="3.16.1" date="2015-05-11" />
++    <release version="3.16.0" date="2015-03-23" />
++    <release version="3.15.91" date="2015-03-02" />
++    <release version="3.15.90" date="2015-02-16" />
++    <release version="3.14.2" date="2015-05-18" />
++    <release version="3.14.1" date="2014-10-13" />
++    <release version="3.14.0" date="2014-09-22" />
++    <release version="3.13.92" date="2014-09-15" />
++    <release version="3.13.90" date="2014-08-19" />
++    <release version="3.13.3" date="2014-06-23" />
++    <release version="3.12.0" date="2014-03-24" />
++    <release version="3.11.91" date="2014-03-03" />
++    <release version="3.11.1" date="2013-11-19" />
++    <release version="3.10.2" date="2014-03-03" />
++    <release version="3.10.1" date="2013-10-15" />
++    <release version="3.10.0" date="2013-09-23" />
++    <release version="3.9.91" date="2013-09-03" />
++    <release version="3.9.90" date="2013-08-19" />
++    <release version="3.8.1" date="2013-05-13" />
++    <release version="3.8.0" date="2013-03-25" />
++    <release version="3.7.90" date="2013-02-18" />
++    <release version="3.7.4" date="2013-01-14" />
++    <release version="3.7.3" date="2012-12-19" />
++    <release version="3.6.2" date="2012-11-12" />
++    <release version="3.6.1" date="2012-10-15" />
++    <release version="3.6.0" date="2012-09-24" />
++    <release version="3.5.92" date="2012-09-17" />
++    <release version="3.5.91" date="2012-09-04" />
++    <release version="3.5.90" date="2012-08-20" />
++    <release version="3.4.2" date="2012-05-15" />
++    <release version="3.4.1" date="2012-04-16" />
++    <release version="3.4.0" date="2012-03-26" />
++    <release version="3.3.92" date="2012-03-19" />
++    <release version="3.3.4" date="2012-02-23" />
++    <release version="3.3.3" date="2012-01-17" />
++    <release version="3.3.2" date="2011-12-21" />
++    <release version="3.3.1" date="2011-10-25" />
++    <release version="3.2.1" date="2011-10-17" />
++    <release version="3.2.0" date="2011-09-26" />
++    <release version="3.1.4" date="2011-09-19" />
++    <release version="3.1.3" date="2011-09-05" />
++    <release version="3.1.2" date="2011-08-15" />
++    <release version="3.1.1" date="2011-06-13" />
++    <release version="3.0.4" date="2011-06-24" />
++    <release version="3.0.3" date="2011-05-23" />
++    <release version="3.0.2" date="2011-04-25" />
++    <release version="3.0.1" date="2011-04-10" />
++    <release version="3.0.0" date="2011-04-04" />
++    <release version="2.91.92" date="2011-03-22" />
++    <release version="2.91.91" date="2011-03-07" />
++    <release version="2.91.90" date="2011-02-21" />
++    <release version="2.91.10" date="2011-01-10" />
++    <release version="2.91.9" date="2010-12-23" />
++    <release version="2.91.8" date="2010-12-16" />
++    <release version="2.31.7" date="2010-07-12" />
++    <release version="2.31.6" date="2010-06-29" />
++    <release version="2.31.5" date="2010-06-07" />
++    <release version="2.31.4" date="2010-05-27" />
++    <release version="2.31.3" date="2010-05-27" />
++    <release version="2.31.2" date="2010-05-03" />
++    <release version="2.31.1" date="2010-04-24" />
++    <release version="2.30.2" date="2010-09-28" />
++    <release version="2.30.1" date="2010-04-26" />
++    <release version="2.30.0" date="2010-03-29" />
++    <release version="2.29.5" date="2010-02-21" />
++    <release version="2.29.4" date="2010-02-08" />
++    <release version="2.29.3" date="2010-01-25" />
++    <release version="2.29.2" date="2010-01-11" />
++    <release version="2.29.1" date="2010-01-05" />
++    <release version="2.28.1" date="2009-11-19" />
++    <release version="2.28.0" date="2009-09-21" />
++    <release version="2.27.5" date="2009-09-07" />
++    <release version="2.27.4" date="2009-08-24" />
++    <release version="2.27.3" date="2009-07-27" />
++    <release version="2.27.2" date="2009-06-29" />
++    <release version="2.27.1" date="2009-06-14" />
++  </releases>
+ </component>
+-- 
+2.25.1
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 #02_man-utf8.patch
 #04_use_doc-base.patch
 disable_package_search.patch
+required-content_rating-and-releases-appdata.patch

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 export DEB_LDFLAGS_MAINT_APPEND = -Wl,-O1 -Wl,-z,defs -Wl,--as-needed
 
 %:
-	dh $@ --with gnome,eoscontent
+	dh $@ --with gnome
 
 override_dh_auto_clean:
 	dh_auto_clean

--- a/debian/yelp.install
+++ b/debian/yelp.install
@@ -1,4 +1,6 @@
 usr/share/applications
+usr/share/dbus-1
+usr/share/gnome-shell
 usr/share/glib-2.0/schemas
 usr/share/icons
 usr/share/locale
@@ -7,3 +9,4 @@ usr/share/yelp
 usr/share/yelp-xsl
 usr/bin
 debian/source_yelp.py usr/share/apport/package-hooks/
+usr/libexec/yelp-search-provider

--- a/debian/yelp.install
+++ b/debian/yelp.install
@@ -1,6 +1,4 @@
 usr/share/applications
-usr/share/dbus-1
-usr/share/gnome-shell
 usr/share/glib-2.0/schemas
 usr/share/icons
 usr/share/locale
@@ -9,4 +7,3 @@ usr/share/yelp
 usr/share/yelp-xsl
 usr/bin
 debian/source_yelp.py usr/share/apport/package-hooks/
-usr/libexec/yelp-search-provider


### PR DESCRIPTION
Debian packaging for rebasing on 3.38.

Code changes are in #65.

This moves us closer to the upstream Debian packaging, as the `eoscontent` support can be dropped due to dropping our style customisations. The only divergence from Debian now is the search provider, which is still not accepted upstream.

https://phabricator.endlessm.com/T30176