### PR TITLE
Update to 3.38.3 (packaging)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+yelp (3.38.3-0endless1) eos; urgency=medium
+
+  * New upstream release (T31755)
+  * Debian packaging not updated
+
+ -- Will Thompson <wjt@endlessos.org>  Wed, 22 Sep 2021 14:29:07 +0100
+
 yelp (3.38.0-1endless0) eos; urgency=medium
 
   * Re-apply Endless changes on latest upstream release (T30176):


### PR DESCRIPTION
I haven't refreshed the packaging from Debian. I had a glance over the
Salsa git history and it didn't seem worth the rigmarole.

https://phabricator.endlessm.com/T31755
